### PR TITLE
The handshake must also be destroyed during a timer reset. Compare wg_q…

### DIFF
--- a/src/wireguard.c
+++ b/src/wireguard.c
@@ -444,6 +444,16 @@ bool wireguard_check_mac2(struct wireguard_device *device, const uint8_t *data, 
 	return result;
 }
 
+void handshake_destroy(struct wireguard_handshake *handshake) {
+	crypto_zero(handshake->ephemeral_private, WIREGUARD_PUBLIC_KEY_LEN);
+	crypto_zero(handshake->remote_ephemeral, WIREGUARD_PUBLIC_KEY_LEN);
+	crypto_zero(handshake->hash, WIREGUARD_HASH_LEN);
+	crypto_zero(handshake->chaining_key, WIREGUARD_HASH_LEN);
+	handshake->remote_index = 0;
+	handshake->local_index = 0;
+	handshake->valid = false;
+}
+
 void keypair_destroy(struct wireguard_keypair *keypair) {
 	crypto_zero(keypair, sizeof(struct wireguard_keypair));
 	keypair->valid = false;

--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -863,7 +863,7 @@ static void wireguardif_tmr(void *arg) {
 				keypair_destroy(&peer->next_keypair);
 				keypair_destroy(&peer->curr_keypair);
 				keypair_destroy(&peer->prev_keypair);
-				// TODO: Also destroy handshake?
+				handshake_destroy(&peer->handshake);
 
 				// Revert back to default IP/port if these were altered
 				peer->ip = peer->connect_ip;


### PR DESCRIPTION
…ueued_expired_zero_key_material in the file https://git.zx2c4.com/wireguard-linux/tree/drivers/net/wireguard/timers.c