### PR TITLE
Resolve "implicit declaration of function 'handshake_destroy'" error …

### DIFF
--- a/src/wireguard.h
+++ b/src/wireguard.h
@@ -271,6 +271,7 @@ bool wireguard_process_cookie_message(struct wireguard_device *device, struct wi
 bool wireguard_create_handshake_initiation(struct wireguard_device *device, struct wireguard_peer *peer, struct message_handshake_initiation *dst);
 bool wireguard_create_handshake_response(struct wireguard_device *device, struct wireguard_peer *peer, struct message_handshake_response *dst);
 void wireguard_create_cookie_reply(struct wireguard_device *device, struct message_cookie_reply *dst, const uint8_t *mac1, uint32_t index, uint8_t *source_addr_port, size_t source_length);
+void handshake_destroy(struct wireguard_handshake *handshake);
 
 
 bool wireguard_check_mac1(struct wireguard_device *device, const uint8_t *data, size_t len, const uint8_t *mac1);


### PR DESCRIPTION
…in wireguardif.c by

Microsoft Intellisense reports this error in VSC + Platformio:
`implicit declaration of function 'handshake_destroy'; did you mean 'keypair_destroy'? [-Wimplicit-function-declaration]`