### PR TITLE
Add new constructor to let you pass the underline netif (e.g. for PPPoS)

### DIFF
--- a/src/WireGuard-ESP32.h
+++ b/src/WireGuard-ESP32.h
@@ -4,12 +4,25 @@
  */
 #pragma once
 #include <IPAddress.h>
+#include <stdint.h>
+
+typedef struct {
+  IPAddress localIP;
+  IPAddress gateway;
+  IPAddress subnet;
+  const char *privateKey;
+  const char *peerHost;
+  uint16_t peerPort;
+  const char *peerPublickKey;
+  struct netif *underlineNetif;
+} WireGuardConfig;
 
 class WireGuard
 {
 private:
     bool _is_initialized = false;
 public:
+    bool begin(WireGuardConfig *config);
     bool begin(const IPAddress& localIP, const IPAddress& Subnet, const IPAddress& Gateway, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
     bool begin(const IPAddress& localIP, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
     void end();

--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -920,10 +920,6 @@ err_t wireguardif_init(struct netif *netif) {
 	uint8_t private_key[WIREGUARD_PRIVATE_KEY_LEN];
 	size_t private_key_len = sizeof(private_key);
 
-	struct netif* underlying_netif;
-	tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, &underlying_netif);
-	log_i(TAG "underlying_netif = %p", underlying_netif);
-
 	LWIP_ASSERT("netif != NULL", (netif != NULL));
 	LWIP_ASSERT("state != NULL", (netif->state != NULL));
 
@@ -950,7 +946,7 @@ err_t wireguardif_init(struct netif *netif) {
 					device = (struct wireguard_device *)mem_calloc(1, sizeof(struct wireguard_device));
 					if (device) {
 						device->netif = netif;
-						device->underlying_netif = underlying_netif;
+						device->underlying_netif = init_data->bind_netif;
 						//udp_bind_netif(udp, underlying_netif);
 
 						device->udp_pcb = udp;


### PR DESCRIPTION
At the moment the library works only via WiFi (STA, not in AP mode). That is because all the data is written and read to a fixed "underline netif".

With this PR the application can pass a "struct netif" to the constructor so then the library uses that netif as "underline netif". If "struct netif" is NULL then library use the default WiFi STA netif.

To pass the netif I did a refactor to the constructor: the new constructor accepts just one argument that is a config struct. In the future maybe we can also add the presharedKey easly (now preshardKey is NULL by default and unchangable by the application).

This PR let the application to specify the underline netif, so the application can pass as underline netif a the PPPoS netif.