### PR TITLE
Add support for more configuration settings

### DIFF
--- a/src/WireGuard-ESP32.h
+++ b/src/WireGuard-ESP32.h
@@ -11,6 +11,8 @@ private:
     bool _is_initialized = false;
 public:
     bool begin(const IPAddress& localIP, const IPAddress& Subnet, const IPAddress& Gateway, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
+    bool begin(const IPAddress& localIP, const IPAddress& Subnet, const IPAddress& Gateway, const char* privateKey, const IPAddress& DNS, uint16_t mtu);
+    bool addPeer(const char* address, uint16_t port, const char* publicKey, const char* preSharedKey, const IPAddress& allowedAddr, const IPAddress& allowedMask, uint16_t keep_alive);
     bool begin(const IPAddress& localIP, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
     void end();
     bool is_initialized() const { return this->_is_initialized; }

--- a/src/WireGuard-ESP32.h
+++ b/src/WireGuard-ESP32.h
@@ -16,4 +16,5 @@ public:
     bool begin(const IPAddress& localIP, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
     void end();
     bool is_initialized() const { return this->_is_initialized; }
+    bool isUp(IPAddress& peerIP);
 };

--- a/src/WireGuard.cpp
+++ b/src/WireGuard.cpp
@@ -191,3 +191,18 @@ void WireGuard::end() {
 
 	this->_is_initialized = false;
 }
+
+bool WireGuard::isUp(IPAddress& peerIP) {
+	ip_addr_t peer_ip;
+	err_t err;
+
+	peerIP = IPAddress(0,0,0,0);
+	if (!_is_initialized || (wireguard_peer_index == WIREGUARDIF_INVALID_INDEX)) {
+		return false;
+	}
+	err = wireguardif_peer_is_up(wg_netif, wireguard_peer_index, &peer_ip, NULL);
+	if (err != ERR_ARG) {
+		peerIP = ip4_addr_get_u32(ip_2_ip4(&peer_ip));
+	}
+	return (err == ERR_OK);
+}

--- a/src/WireGuard.cpp
+++ b/src/WireGuard.cpp
@@ -181,12 +181,12 @@ void WireGuard::end() {
 		wireguardif_remove_peer(wg_netif, wireguard_peer_index);
 		wireguard_peer_index = WIREGUARDIF_INVALID_INDEX;
 	}
-	// Shutdown the wireguard interface.
-	wireguardif_shutdown(wg_netif);
 	// Remove the WG interface;
 	WG_MUTEX_LOCK();
 	netif_remove(wg_netif);
 	WG_MUTEX_UNLOCK();
+	// Shutdown the wireguard interface.
+	wireguardif_shutdown(wg_netif);
 	wg_netif = nullptr;
 
 	this->_is_initialized = false;

--- a/src/wireguard.h
+++ b/src/wireguard.h
@@ -256,6 +256,7 @@ struct wireguard_peer *peer_lookup_by_handshake(struct wireguard_device *device,
 
 void wireguard_start_session(struct wireguard_peer *peer, bool initiator);
 
+void handshake_destroy(struct wireguard_handshake *handshake);
 void keypair_update(struct wireguard_peer *peer, struct wireguard_keypair *received_keypair);
 void keypair_destroy(struct wireguard_keypair *keypair);
 

--- a/src/wireguardif.h
+++ b/src/wireguardif.h
@@ -58,8 +58,8 @@ struct wireguardif_init_data {
 
 struct wireguardif_peer {
 	const char *public_key;
-	// Optional pre-shared key (32 bytes) - make sure this is NULL if not to be used
-	const uint8_t *preshared_key;
+	// Optional pre-shared key - make sure this is NULL if not to be used
+	const char *preshared_key;
 	// tai64n of largest timestamp we have seen during handshake to avoid replays
 	uint8_t greatest_timestamp[12];
 


### PR DESCRIPTION
These changes add a new WireGuard::begin() method, which allows specifying additional settings such as a DNS server and an MTU value, but does not add a remote peer for the WireGuard client; to add a peer after this begin() call, a WireGuard::addPeer() method is now defined, which (compared to the existing begin() methods) allows specifying additional settings such as a pre-shared key, a set of allowed IP addresses, and a keep-alive interval.

In addition:
- the code has been updated to support Arduino core version 3,x, incorporating changes by @martinusGH and @pierrejay
- a bug in WireGuard::end() has been fixed