### PR TITLE
feat: migrate to ESP-NETIF and expose esp_netif handle

### DIFF
--- a/src/WireGuard-ESP32.h
+++ b/src/WireGuard-ESP32.h
@@ -10,10 +10,11 @@ class WireGuard
 {
 private:
     bool _is_initialized = false;
+
 public:
-    esp_netif_t* netif();
-    bool begin(const IPAddress& localIP, const IPAddress& Subnet, const IPAddress& Gateway, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
-    bool begin(const IPAddress& localIP, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
+    esp_netif_t *netif();
+    bool begin(const IPAddress &localIP, const IPAddress &Subnet, const IPAddress &Gateway, const char *privateKey, const char *remotePeerAddress, const char *remotePeerPublicKey, uint16_t remotePeerPort);
+    bool begin(const IPAddress &localIP, const char *privateKey, const char *remotePeerAddress, const char *remotePeerPublicKey, uint16_t remotePeerPort);
     void end();
     bool is_initialized() const { return this->_is_initialized; }
 };

--- a/src/WireGuard-ESP32.h
+++ b/src/WireGuard-ESP32.h
@@ -4,12 +4,14 @@
  */
 #pragma once
 #include <IPAddress.h>
+#include "esp_netif.h"
 
 class WireGuard
 {
 private:
     bool _is_initialized = false;
 public:
+    esp_netif_t* netif();
     bool begin(const IPAddress& localIP, const IPAddress& Subnet, const IPAddress& Gateway, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
     bool begin(const IPAddress& localIP, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort);
     void end();

--- a/src/WireGuard.cpp
+++ b/src/WireGuard.cpp
@@ -60,7 +60,7 @@ static void wg_lwip_input(void *h, void *buffer, size_t len, void *eb)
 
 static esp_err_t wg_driver_transmit(void *h, void *buffer, size_t len)
 {
-	log_w(TAG, "wg_driver_transmit called unexpectedly, len=%u", (unsigned)len);
+	log_w(TAG "wg_driver_transmit called unexpectedly, len=%u", (unsigned)len);
 	esp_netif_free_rx_buffer(h, buffer);
 
 	return ESP_OK;
@@ -173,7 +173,7 @@ bool WireGuard::begin(const IPAddress &localIP, const IPAddress &Subnet, const I
 	wg_esp_netif = esp_netif_new(&cfg);
 	if (!wg_esp_netif)
 	{
-		log_w(TAG, "esp_netif_new failed");
+		log_w(TAG "esp_netif_new failed");
 		return false;
 	}
 

--- a/src/WireGuard.cpp
+++ b/src/WireGuard.cpp
@@ -24,7 +24,8 @@
 
 #include "esp32-hal-log.h"
 
-extern "C" {
+extern "C"
+{
 #include "wireguardif.h"
 #include "wireguard-platform.h"
 }
@@ -38,57 +39,60 @@ static uint8_t wireguard_peer_index = WIREGUARDIF_INVALID_INDEX;
 
 #define TAG "[WireGuard] "
 
-typedef struct {
-    esp_netif_driver_base_t base;
-    struct netif *lwip_nif;
+typedef struct
+{
+	esp_netif_driver_base_t base;
+	struct netif *lwip_nif;
 } wg_driver_glue_t;
 
 static err_t wg_lwip_init(netif *netif)
 {
-    return ERR_OK;
+	return ERR_OK;
 }
 
 static void wg_lwip_input(void *h, void *buffer, size_t len, void *eb)
 {
-    if (buffer) {
-        pbuf_free((struct pbuf *)buffer);
-    }
+	if (buffer)
+	{
+		pbuf_free((struct pbuf *)buffer);
+	}
 }
 
 static esp_err_t wg_driver_transmit(void *h, void *buffer, size_t len)
 {
-    log_w(TAG, "wg_driver_transmit called unexpectedly, len=%u", (unsigned)len);
-    esp_netif_free_rx_buffer(h, buffer);
+	log_w(TAG, "wg_driver_transmit called unexpectedly, len=%u", (unsigned)len);
+	esp_netif_free_rx_buffer(h, buffer);
 
-    return ESP_OK;
+	return ESP_OK;
 }
 
 static void wg_driver_free_rx(void *h, void *buffer) {}
 
 static esp_err_t wg_post_attach(esp_netif_t *esp_netif, void *args)
 {
-    wg_driver_glue_t *glue = (wg_driver_glue_t *)args;
-    const esp_netif_driver_ifconfig_t ifc = {
-        .handle               = glue,
-        .transmit             = wg_driver_transmit,
-        .driver_free_rx_buffer= wg_driver_free_rx,
-    };
-    esp_netif_set_driver_config(esp_netif, &ifc);
-    glue->base.netif = esp_netif;
+	wg_driver_glue_t *glue = (wg_driver_glue_t *)args;
+	const esp_netif_driver_ifconfig_t ifc = {
+			.handle = glue,
+			.transmit = wg_driver_transmit,
+			.driver_free_rx_buffer = wg_driver_free_rx,
+	};
+	esp_netif_set_driver_config(esp_netif, &ifc);
+	glue->base.netif = esp_netif;
 
-    return ESP_OK;
+	return ESP_OK;
 }
 
 /* ------------------------------------------------------------- */
 static wg_driver_glue_t *create_wg_glue(struct netif *lwip)
 {
-    auto *g = (wg_driver_glue_t*)calloc(1, sizeof(wg_driver_glue_t));
-		g->base.post_attach = wg_post_attach;
-    g->lwip_nif                = lwip;
-    return g;
+	auto *g = (wg_driver_glue_t *)calloc(1, sizeof(wg_driver_glue_t));
+	g->base.post_attach = wg_post_attach;
+	g->lwip_nif = lwip;
+	return g;
 }
 
-bool WireGuard::begin(const IPAddress& localIP, const IPAddress& Subnet, const IPAddress& Gateway, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort) {
+bool WireGuard::begin(const IPAddress &localIP, const IPAddress &Subnet, const IPAddress &Gateway, const char *privateKey, const char *remotePeerAddress, const char *remotePeerPublicKey, uint16_t remotePeerPort)
+{
 	struct wireguardif_init_data wg;
 	struct wireguardif_peer peer;
 	ip_addr_t ipaddr = IPADDR4_INIT(static_cast<uint32_t>(localIP));
@@ -102,48 +106,46 @@ bool WireGuard::begin(const IPAddress& localIP, const IPAddress& Subnet, const I
 
 	// Setup the WireGuard device structure
 	wg.private_key = privateKey;
-    wg.listen_port = remotePeerPort;
-	
+	wg.listen_port = remotePeerPort;
+
 	wg.bind_netif = NULL;
 
 	// Initialise the first WireGuard peer structure
 	wireguardif_peer_init(&peer);
 	// If we know the endpoint's address can add here
 	bool success_get_endpoint_ip = false;
-    for(int retry = 0; retry < 5; retry++) {
-        ip_addr_t endpoint_ip = IPADDR4_INIT_BYTES(0, 0, 0, 0);
-        struct addrinfo *res = NULL;
-        struct addrinfo hint;
-        memset(&hint, 0, sizeof(hint));
-        memset(&endpoint_ip, 0, sizeof(endpoint_ip));
-        if( lwip_getaddrinfo(remotePeerAddress, NULL, &hint, &res) != 0 ) {
+	for (int retry = 0; retry < 5; retry++)
+	{
+		ip_addr_t endpoint_ip = IPADDR4_INIT_BYTES(0, 0, 0, 0);
+		struct addrinfo *res = NULL;
+		struct addrinfo hint;
+		memset(&hint, 0, sizeof(hint));
+		memset(&endpoint_ip, 0, sizeof(endpoint_ip));
+		if (lwip_getaddrinfo(remotePeerAddress, NULL, &hint, &res) != 0)
+		{
 			vTaskDelay(pdMS_TO_TICKS(2000));
 			continue;
 		}
 		success_get_endpoint_ip = true;
-        struct in_addr addr4 = ((struct sockaddr_in *) (res->ai_addr))->sin_addr;
-        inet_addr_to_ip4addr(ip_2_ip4(&endpoint_ip), &addr4);
-        lwip_freeaddrinfo(res);
+		struct in_addr addr4 = ((struct sockaddr_in *)(res->ai_addr))->sin_addr;
+		inet_addr_to_ip4addr(ip_2_ip4(&endpoint_ip), &addr4);
+		lwip_freeaddrinfo(res);
 
-        peer.endpoint_ip = endpoint_ip;
-        log_i(TAG "%s is %3d.%3d.%3d.%3d"
-			, remotePeerAddress
-            , (endpoint_ip.u_addr.ip4.addr >>  0) & 0xff
-            , (endpoint_ip.u_addr.ip4.addr >>  8) & 0xff
-            , (endpoint_ip.u_addr.ip4.addr >> 16) & 0xff
-            , (endpoint_ip.u_addr.ip4.addr >> 24) & 0xff
-            );
+		peer.endpoint_ip = endpoint_ip;
+		log_i(TAG "%s is %3d.%3d.%3d.%3d", remotePeerAddress, (endpoint_ip.u_addr.ip4.addr >> 0) & 0xff, (endpoint_ip.u_addr.ip4.addr >> 8) & 0xff, (endpoint_ip.u_addr.ip4.addr >> 16) & 0xff, (endpoint_ip.u_addr.ip4.addr >> 24) & 0xff);
 		break;
-    }
-	if( !success_get_endpoint_ip  ) {
+	}
+	if (!success_get_endpoint_ip)
+	{
 		log_e(TAG "failed to get endpoint ip.");
 		return false;
 	}
-	
+
 	LOCK_TCPIP_CORE();
 	// Register the new WireGuard network interface with lwIP
 	wg_netif = netif_add(&wg_netif_struct, ip_2_ip4(&ipaddr), ip_2_ip4(&netmask), ip_2_ip4(&gateway), &wg, &wireguardif_init, &ip_input);
-	if( wg_netif == nullptr ) {
+	if (wg_netif == nullptr)
+	{
 		log_e(TAG "failed to initialize WG netif.");
 		return false;
 	}
@@ -152,26 +154,26 @@ bool WireGuard::begin(const IPAddress& localIP, const IPAddress& Subnet, const I
 	esp_netif_inherent_config_t inh = ESP_NETIF_INHERENT_DEFAULT_ETH();
 	inh.flags = (esp_netif_flags_t)(ESP_NETIF_FLAG_AUTOUP);
 	inh.route_prio = 20;
-  inh.get_ip_event = 0;
-  inh.lost_ip_event = 0;
+	inh.get_ip_event = 0;
+	inh.lost_ip_event = 0;
 	inh.if_key = "WG_DEF";
 	inh.if_desc = "wg";
 
 	static const esp_netif_netstack_config_t wg_netstack = {
 			.lwip = {
-					.init_fn  = wg_lwip_init,
+					.init_fn = wg_lwip_init,
 					.input_fn = wg_lwip_input,
-			}
-	};
+			}};
 	esp_netif_config_t cfg = {
-			.base     = &inh,
-			.driver   = nullptr,
-			.stack    = &wg_netstack,
+			.base = &inh,
+			.driver = nullptr,
+			.stack = &wg_netstack,
 	};
 
 	wg_esp_netif = esp_netif_new(&cfg);
-	if (!wg_esp_netif) {
-		log_w(TAG,"esp_netif_new failed");
+	if (!wg_esp_netif)
+	{
+		log_w(TAG, "esp_netif_new failed");
 		return false;
 	}
 
@@ -182,10 +184,10 @@ bool WireGuard::begin(const IPAddress& localIP, const IPAddress& Subnet, const I
 	ip_event_got_ip_t evt = {};
 	evt.esp_netif = wg_esp_netif;
 	evt.ip_changed = true;
-	evt.ip_info.ip.addr      = ipaddr.u_addr.ip4.addr;
-	evt.ip_info.gw.addr      = gateway.u_addr.ip4.addr;
+	evt.ip_info.ip.addr = ipaddr.u_addr.ip4.addr;
+	evt.ip_info.gw.addr = gateway.u_addr.ip4.addr;
 	evt.ip_info.netmask.addr = netmask.u_addr.ip4.addr;
-	
+
 	esp_netif_set_ip_info(wg_esp_netif, &evt.ip_info);
 	esp_netif_action_connected(wg_esp_netif, NULL, 0, NULL);
 
@@ -198,48 +200,53 @@ bool WireGuard::begin(const IPAddress& localIP, const IPAddress& Subnet, const I
 	peer.public_key = remotePeerPublicKey;
 	peer.preshared_key = NULL;
 	// Allow all IPs through tunnel
-    {
-        ip_addr_t allowed_ip = IPADDR4_INIT_BYTES(0, 0, 0, 0);
-        peer.allowed_ip = allowed_ip;
-        ip_addr_t allowed_mask = IPADDR4_INIT_BYTES(0, 0, 0, 0);
-        peer.allowed_mask = allowed_mask;
-    }
-	
+	{
+		ip_addr_t allowed_ip = IPADDR4_INIT_BYTES(0, 0, 0, 0);
+		peer.allowed_ip = allowed_ip;
+		ip_addr_t allowed_mask = IPADDR4_INIT_BYTES(0, 0, 0, 0);
+		peer.allowed_mask = allowed_mask;
+	}
+
 	peer.endport_port = remotePeerPort;
 
-    // Initialize the platform
-    wireguard_platform_init();
+	// Initialize the platform
+	wireguard_platform_init();
 	// Register the new WireGuard peer with the netwok interface
 	wireguardif_add_peer(wg_netif, &peer, &wireguard_peer_index);
-	if ((wireguard_peer_index != WIREGUARDIF_INVALID_INDEX) && !ip_addr_isany(&peer.endpoint_ip)) {
+	if ((wireguard_peer_index != WIREGUARDIF_INVALID_INDEX) && !ip_addr_isany(&peer.endpoint_ip))
+	{
 		// Start outbound connection to peer
-        log_i(TAG "connecting wireguard...");
+		log_i(TAG "connecting wireguard...");
 		wireguardif_connect(wg_netif, wireguard_peer_index);
 		// Save the current default interface for restoring when shutting down the WG interface.
 		previous_default_netif = netif_default;
 		// Set default interface to WG device.
-				LOCK_TCPIP_CORE();
-        netif_set_default(wg_netif);
-				UNLOCK_TCPIP_CORE();
+		LOCK_TCPIP_CORE();
+		netif_set_default(wg_netif);
+		UNLOCK_TCPIP_CORE();
 	}
 
 	this->_is_initialized = true;
 	return true;
 }
 
-esp_netif_t* WireGuard::netif() {
+esp_netif_t *WireGuard::netif()
+{
 	return wg_esp_netif;
 }
 
-bool WireGuard::begin(const IPAddress& localIP, const char* privateKey, const char* remotePeerAddress, const char* remotePeerPublicKey, uint16_t remotePeerPort) {
-	// Maintain compatiblity with old begin 
-	auto subnet = IPAddress(255,255,255,255);
-	auto gateway = IPAddress(0,0,0,0);
+bool WireGuard::begin(const IPAddress &localIP, const char *privateKey, const char *remotePeerAddress, const char *remotePeerPublicKey, uint16_t remotePeerPort)
+{
+	// Maintain compatiblity with old begin
+	auto subnet = IPAddress(255, 255, 255, 255);
+	auto gateway = IPAddress(0, 0, 0, 0);
 	return WireGuard::begin(localIP, subnet, gateway, privateKey, remotePeerAddress, remotePeerPublicKey, remotePeerPort);
 }
 
-void WireGuard::end() {
-	if( !this->_is_initialized ) return;
+void WireGuard::end()
+{
+	if (!this->_is_initialized)
+		return;
 
 	LOCK_TCPIP_CORE();
 	// Restore the default interface.

--- a/src/crypto/refc/x25519.c
+++ b/src/crypto/refc/x25519.c
@@ -129,7 +129,7 @@ swapout(uint8_t *out, limb_t *x) {
     memcpy(out,x,sizeof(fe));
 }
 
-static void mul(fe out, const fe a, const fe b, unsigned nb) {
+static void mul(fe out, const fe a, const limb_t *b, unsigned nb) {
     /* GCC at least produces pretty decent asm for this, so don't need to have dedicated asm. */
     limb_t accum[2*NLIMBS] = {0};
     unsigned i,j;

--- a/src/wireguard.h
+++ b/src/wireguard.h
@@ -256,6 +256,8 @@ struct wireguard_peer *peer_lookup_by_handshake(struct wireguard_device *device,
 
 void wireguard_start_session(struct wireguard_peer *peer, bool initiator);
 
+void handshake_destroy(struct wireguard_handshake *handshake);
+
 void keypair_update(struct wireguard_peer *peer, struct wireguard_keypair *received_keypair);
 void keypair_destroy(struct wireguard_keypair *keypair);
 

--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -89,17 +89,13 @@ static err_t wireguardif_peer_output(struct netif *netif, struct pbuf *q, struct
 	struct wireguard_device *device = (struct wireguard_device *)netif->state;
 	// Send to last know port, not the connect port
 	//TODO: Support DSCP and ECN - lwip requires this set on PCB globally, not per packet
-	LOCK_TCPIP_CORE();
 	err_t err = udp_sendto_if(device->udp_pcb, q, &peer->ip, peer->port, device->underlying_netif);
-	UNLOCK_TCPIP_CORE();
 
 	return err;
 }
 
 static err_t wireguardif_device_output(struct wireguard_device *device, struct pbuf *q, const ip_addr_t *ipaddr, u16_t port) {
-	LOCK_TCPIP_CORE();
 	err_t err = udp_sendto_if(device->udp_pcb, q, ipaddr, port, device->underlying_netif);
-	UNLOCK_TCPIP_CORE();
 	return err;
 }
 
@@ -231,9 +227,7 @@ static void wireguardif_process_response_message(struct wireguard_device *device
 		wireguardif_send_keepalive(device, peer);
 
 		// Set the IF-UP flag on netif
-		LOCK_TCPIP_CORE();
 		netif_set_link_up(device->netif);
-		UNLOCK_TCPIP_CORE();
 	} else {
 		// Packet bad
 		log_i(TAG "bad handshake from %08x:%d", addr->u_addr.ip4.addr, port);
@@ -320,9 +314,7 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 					}
 
 					// Make sure that link is reported as up
-					LOCK_TCPIP_CORE();
 					netif_set_link_up(device->netif);
-					UNLOCK_TCPIP_CORE();
 
 					if (pbuf->tot_len > 0) {
 						//4a. Once the packet payload is decrypted, the interface has a plaintext packet. If this is not an IP packet, it is dropped.
@@ -902,9 +894,7 @@ static void wireguardif_tmr(void *arg) {
 
 	if (!link_up) {
 		// Clear the IF-UP flag on netif
-		LOCK_TCPIP_CORE();
 		netif_set_link_down(device->netif);
-		UNLOCK_TCPIP_CORE();
 	}
 }
 
@@ -917,10 +907,8 @@ void wireguardif_shutdown(struct netif *netif) {
 	sys_untimeout(wireguardif_tmr, device);
 	// remove UDP context.
 	if( device->udp_pcb ) {
-		LOCK_TCPIP_CORE();
 		udp_disconnect(device->udp_pcb);
 		udp_remove(device->udp_pcb);
-		UNLOCK_TCPIP_CORE();
 		device->udp_pcb = NULL;
 	}
 	// remove device context.
@@ -950,9 +938,7 @@ err_t wireguardif_init(struct netif *netif) {
 	    result = ERR_IF;
 	    goto fail;
 	}
-	LOCK_TCPIP_CORE();
 	underlying_netif = netif_find(lwip_netif_name);
-	UNLOCK_TCPIP_CORE();
 	if (underlying_netif == NULL) {
 	    ESP_LOGE(TAG, "netif_find: cannot find WIFI_STA_DEF");
 	    result = ERR_IF;
@@ -979,14 +965,10 @@ err_t wireguardif_init(struct netif *netif) {
 		if (wireguard_base64_decode(init_data->private_key, private_key, &private_key_len)
 				&& (private_key_len == WIREGUARD_PRIVATE_KEY_LEN)) {
 			
-			LOCK_TCPIP_CORE();
 			udp = udp_new();
-			UNLOCK_TCPIP_CORE();
 
 			if (udp) {
-				LOCK_TCPIP_CORE();
 				result = udp_bind(udp, IP_ADDR_ANY, init_data->listen_port); // Note this listens on all interfaces! Really just want the passed netif
-				UNLOCK_TCPIP_CORE();
 
 				if (result == ERR_OK) {
 					device = (struct wireguard_device *)mem_calloc(1, sizeof(struct wireguard_device));
@@ -1017,9 +999,7 @@ err_t wireguardif_init(struct netif *netif) {
 							// NETIF_FLAG_LINK_UP is automatically set/cleared when at least one peer is connected
 							netif->flags = 0;
 
-							LOCK_TCPIP_CORE();
 							udp_recv(udp, wireguardif_network_rx, device);
-							UNLOCK_TCPIP_CORE();
 
 							// Start a periodic timer for this wireguard device
 							sys_timeout(WIREGUARDIF_TIMER_MSECS, wireguardif_tmr, device);
@@ -1029,23 +1009,17 @@ err_t wireguardif_init(struct netif *netif) {
 							log_e(TAG "failed to initialize WireGuard device.");
 							mem_free(device);
 							device = NULL;
-							LOCK_TCPIP_CORE();
 							udp_remove(udp);
-							UNLOCK_TCPIP_CORE();
 							result = ERR_ARG;
 						}
 					} else {
 						log_e(TAG "failed to allocate device context.");
-						LOCK_TCPIP_CORE();
 						udp_remove(udp);
-						UNLOCK_TCPIP_CORE();
 						result = ERR_MEM;
 					}
 				} else {
 					log_e(TAG "failed to bind UDP err=%d", result);
-					LOCK_TCPIP_CORE();
 					udp_remove(udp);
-					UNLOCK_TCPIP_CORE();
 				}
 
 			} else {

--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -560,7 +560,7 @@ void wireguardif_network_rx(void *arg, struct udp_pcb *pcb, struct pbuf *p, cons
 	struct message_transport_data *msg_data;
 
 	uint8_t type = wireguard_get_message_type(data, len);
-	ESP_LOGV(TAG, "network_rx: %08x:%d", addr->u_addr.ip4.addr, port);
+	log_d(TAG "network_rx: %08x:%d", addr->u_addr.ip4.addr, port);
 
 	switch (type) {
 		case MESSAGE_HANDSHAKE_INITIATION:
@@ -610,7 +610,7 @@ void wireguardif_network_rx(void *arg, struct udp_pcb *pcb, struct pbuf *p, cons
 			break;
 
 		case MESSAGE_TRANSPORT_DATA:
-			ESP_LOGV(TAG, "TRANSPORT_DATA: %08x:%d", addr->u_addr.ip4.addr, port);
+			log_d(TAG "TRANSPORT_DATA: %08x:%d", addr->u_addr.ip4.addr, port);
 
 			msg_data = (struct message_transport_data *)data;
 			peer = peer_lookup_by_receiver(device, msg_data->receiver);
@@ -928,19 +928,19 @@ err_t wireguardif_init(struct netif *netif) {
 	char lwip_netif_name[8] = {0};
 	esp_netif_t *netif_handle = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
 	if (netif_handle == NULL) {
-	    ESP_LOGE(TAG, "No default STA interface");
+	    log_e(TAG "No default STA interface");
 	    result = ERR_IF;
 	    goto fail;
 	}
 	esp_err_t err = esp_netif_get_netif_impl_name(netif_handle, lwip_netif_name);
 	if (err != ESP_OK) {
-	    ESP_LOGE(TAG, "esp_netif_get_netif_impl_name failed: %s", esp_err_to_name(err));
+	    log_e(TAG "esp_netif_get_netif_impl_name failed: %s", esp_err_to_name(err));
 	    result = ERR_IF;
 	    goto fail;
 	}
 	underlying_netif = netif_find(lwip_netif_name);
 	if (underlying_netif == NULL) {
-	    ESP_LOGE(TAG, "netif_find: cannot find WIFI_STA_DEF");
+	    log_e(TAG "netif_find: cannot find WIFI_STA_DEF");
 	    result = ERR_IF;
 	    goto fail;
 	}


### PR DESCRIPTION
## Summary
This PR migrates the WireGuard interface from the raw lwIP netif API to `esp_netif`, the officially supported network abstraction in ESP-IDF ≥ 4.4.  
It also exposes an `esp_netif_t* netif()` accessor so that user code can subscribe to events (e.g. IP acquisition) or tweak DHCP/IPv6 settings.

## Motivation
* Newer Arduino-ESP32 cores (3.x, IDF 5.x) recommend `esp_netif`; direct  `netif_*` calls are considered internal.  
* Using `esp_netif` makes it easier to:
  * inter-operate with other stacks (PPP/LTE, Ethernet).
  * register event handlers with `esp_event`,

## Key changes
* **Add ESP-NETIF support** – create a dedicated `esp_netif` inside   `WireGuard::begin()` and register it with lwIP 
* **Public accessor** `esp_netif_t *netif()` and a new `begin()` overload that  takes Subnet / Gateway 

## Testing
* Platform: ESP32 (M5Stack Core 2), ESP32-S3 (M5Stack AtomS3Cam) / Arduino-ESP32 v3.2.0 (IDF 5.4)
* Verified: handshake + data transfer to a SORACOM Arc endpoint, ICMP ping,  HTTPS download through tunnel.

## Note on overlapping pull requests
I'm aware that some of the changes in this PR overlap with other pull requests that have already been submitted. If those PRs are merged first, I'm happy to re-base or split this patch so that only the remaining changes are applied.